### PR TITLE
Don't load annotations for modified config.

### DIFF
--- a/patcher/patcher.go
+++ b/patcher/patcher.go
@@ -86,7 +86,7 @@ func (p *Patcher) Apply(obj runtime.Object, opts ...OptionFunc) ([]byte, error) 
 	var patch []byte
 	err = r.Visit(func(info *resource.Info, err error) error {
 		// Get the modified configuration of the object.
-		modified, err := GetModifiedConfiguration(p.cfg.name, info, true, encoder)
+		modified, err := GetModifiedConfiguration(p.cfg.name, info, false, encoder)
 		if err != nil {
 			kubekit.Logger.Infof("Error getting the modified configuration for %s: %s", info.Name, err)
 			return err


### PR DESCRIPTION
When we load the modified configuration, we don't want to load the
annotations. Loading the annotations means that we want to add apply
these annotations as changes to our object, whilst in reality, these
should only be applied as a change later on.